### PR TITLE
'fix post_config with jenkins_path '

### DIFF
--- a/lib/jenkins_api_client/client.rb
+++ b/lib/jenkins_api_client/client.rb
@@ -192,7 +192,7 @@ module JenkinsApi
     # @param [String] url_prefix
     #
     def get_config(url_prefix)
-      url_prefix = URI.escape(url_prefix)
+      url_prefix = URI.escape("#{@jenkins_path}#{url_prefix}")
       http = Net::HTTP.start(@server_ip, @server_port)
       request = Net::HTTP::Get.new("#{url_prefix}/config.xml")
       puts "[INFO] GET #{url_prefix}/config.xml" if @debug
@@ -207,7 +207,7 @@ module JenkinsApi
     # @param [String] xml
     #
     def post_config(url_prefix, xml)
-      url_prefix = URI.escape(url_prefix)
+      url_prefix = URI.escape("#{@jenkins_path}#{url_prefix}")
       http = Net::HTTP.start(@server_ip, @server_port)
       request = Net::HTTP::Post.new("#{url_prefix}")
       puts "[INFO] PUT #{url_prefix}" if @debug


### PR DESCRIPTION
HI:

```
api_get_request,api_post_request has the jenkins_path, but get_config and post_config forget it --!
```
