### PR TITLE
Add ability to prompt user for credentials in login_with_irb.rb script.

### DIFF
--- a/scripts/login_with_irb.rb
+++ b/scripts/login_with_irb.rb
@@ -42,7 +42,7 @@ begin
   unless client_opts.has_key?(:username)
     client_opts[:username] = prompt_for_username()
   end
-  unless client_opts.has_key?(:password)
+  unless client_opts.has_key?(:password) or client_opts.has_key?(:password_base64)
     client_opts[:password] = prompt_for_password()
   end
   


### PR DESCRIPTION
Add logic for script to prompt user for missing credentials when running
login_with_irb.rb script, for users who don't want to store passwords in
config files.
