### PR TITLE
response 400 on a build means parameters were missing

### DIFF
--- a/lib/jenkins_api_client/client.rb
+++ b/lib/jenkins_api_client/client.rb
@@ -350,6 +350,8 @@ module JenkinsApi
         elsif to_send == "code"
           return response.code
         end
+      when 400
+        raise Exceptions::NothingSubmitted.new
       when 401
         raise Exceptions::UnautherizedException.new
       when 404

--- a/lib/jenkins_api_client/exceptions.rb
+++ b/lib/jenkins_api_client/exceptions.rb
@@ -31,6 +31,14 @@ module JenkinsApi
       end
     end
 
+    # This exception class handles cases where parameters are expected
+    # but not provided.
+    class NothingSubmitted < ApiException
+      def initialize(message = "")
+        super("Nothing is submitted. #{message}")
+      end
+    end
+
     # This exception class handles cases where invalid credentials are provided
     # to connect to the Jenkins
     class UnautherizedException < ApiException


### PR DESCRIPTION
The request/response look like:

```
    [INFO] PUT /job/Test%20Job/build
    HTTP Code: 400
    Response Body: <html><head><title>Error 400</title></head><body bgcolor="#ffffff"><h1>Status Code: 400</h1>Exception: Nothing is submitted<br>Stacktrace: <pre>(none)
```
