### PR TITLE
Normalize handling of server_url option

### DIFF
--- a/lib/jenkins_api_client/client.rb
+++ b/lib/jenkins_api_client/client.rb
@@ -139,6 +139,7 @@ module JenkinsApi
       @jenkins_path.gsub!(/\/$/,"") # remove trailing slash if there is one
       @server_port = DEFAULT_SERVER_PORT unless @server_port
       @timeout = DEFAULT_TIMEOUT unless @timeout
+      @ssl ||= false
 
       # Setting log options
       @log_location = STDOUT unless @log_location


### PR DESCRIPTION
Normalize handling of the server_url config option by parsing it into
its components (host, port, etc.) in #initialize and using those
components thereafter.
