### PR TITLE
[fixed] insert space between command and arg for CLI

### DIFF
--- a/lib/jenkins_api_client/client.rb
+++ b/lib/jenkins_api_client/client.rb
@@ -463,7 +463,8 @@ module JenkinsApi
       cmd = "java -jar #{base_dir}/../../java_deps/jenkins-cli.jar -s #{server_url}"
       cmd << " -i #{@identity_file}" if @identity_file && !@identity_file.empty?
       cmd << " #{command}"
-      cmd << " --username #{@username} --password #{@password} " if @identity_file.nil? || @identity_file.empty?
+      cmd << " --username #{@username} --password #{@password}" if @identity_file.nil? || @identity_file.empty?
+      cmd << ' '
       cmd << args.join(' ')
       java_cmd = Mixlib::ShellOut.new(cmd)
 


### PR DESCRIPTION
sorry for missing the space here cause the exec_cli failure
