### PR TITLE
Fix URI path/query part escaping

### DIFF
--- a/lib/jenkins_api_client/client.rb
+++ b/lib/jenkins_api_client/client.rb
@@ -321,7 +321,6 @@ module JenkinsApi
       else
         to_get = "#{url_prefix}#{url_suffix}"
       end
-      to_get = URI.escape(to_get)
       request = Net::HTTP::Get.new(to_get)
       @logger.info "GET #{to_get}"
       response = make_http_request(request)
@@ -346,8 +345,7 @@ module JenkinsApi
 
         # Added form_data default {} instead of nil to help with proxies
         # that barf with empty post
-        url_prefix = URI.escape("#{@jenkins_path}#{url_prefix}")
-        request = Net::HTTP::Post.new("#{url_prefix}")
+        request = Net::HTTP::Post.new("#{@jenkins_path}#{url_prefix}")
         @logger.info "POST #{url_prefix}"
         request.content_type = 'application/json'
         if @crumbs_enabled
@@ -386,8 +384,7 @@ module JenkinsApi
     # @return [String] XML configuration obtained from Jenkins
     #
     def get_config(url_prefix)
-      url_prefix = URI.escape("#{@jenkins_path}#{url_prefix}")
-      request = Net::HTTP::Get.new("#{url_prefix}/config.xml")
+      request = Net::HTTP::Get.new("#{@jenkins_path}#{url_prefix}/config.xml")
       @logger.info "GET #{url_prefix}/config.xml"
       response = make_http_request(request)
       handle_exception(response, "body")
@@ -413,8 +410,7 @@ module JenkinsApi
       begin
         refresh_crumbs
 
-        url_prefix = URI.escape("#{@jenkins_path}#{url_prefix}")
-        request = Net::HTTP::Post.new("#{url_prefix}")
+        request = Net::HTTP::Post.new("#{@jenkins_path}#{url_prefix}")
         @logger.info "POST #{url_prefix}"
         request.body = data
         request.content_type = content_type

--- a/lib/jenkins_api_client/job.rb
+++ b/lib/jenkins_api_client/job.rb
@@ -20,12 +20,15 @@
 # THE SOFTWARE.
 #
 
+require 'jenkins_api_client/urihelper'
+
 module JenkinsApi
   class Client
     # This class communicates with the Jenkins "/job" API to obtain details
     # about jobs, creating, deleting, building, and various other operations.
     #
     class Job
+      include JenkinsApi::UriHelper
 
       # Initialize the Job object and store the reference to Client object
       #
@@ -74,7 +77,7 @@ module JenkinsApi
       #
       def create(job_name, xml)
         @logger.info "Creating job '#{job_name}'"
-        @client.post_config("/createItem?name=#{job_name}", xml)
+        @client.post_config("/createItem?name=#{form_encode job_name}", xml)
       end
 
       # Update a job with the name specified and the xml given
@@ -400,7 +403,7 @@ module JenkinsApi
       #
       def rename(old_job, new_job)
         @logger.info "Renaming job '#{old_job}' to '#{new_job}'"
-        @client.api_post_request("/job/#{old_job}/doRename?newName=#{new_job}")
+        @client.api_post_request("/job/#{path_encode old_job}/doRename?newName=#{form_encode new_job}")
       end
 
       # Delete a job given the name
@@ -411,7 +414,7 @@ module JenkinsApi
       #
       def delete(job_name)
         @logger.info "Deleting job '#{job_name}'"
-        @client.api_post_request("/job/#{job_name}/doDelete")
+        @client.api_post_request("/job/#{path_encode job_name}/doDelete")
       end
 
       # Deletes all jobs from Jenkins
@@ -432,7 +435,7 @@ module JenkinsApi
       #
       def wipe_out_workspace(job_name)
         @logger.info "Wiping out the workspace of job '#{job_name}'"
-        @client.api_post_request("/job/#{job_name}/doWipeOutWorkspace")
+        @client.api_post_request("/job/#{path_encode job_name}/doWipeOutWorkspace")
       end
 
       # Stops a running build of a job
@@ -449,10 +452,10 @@ module JenkinsApi
         @logger.info "Stopping job '#{job_name}' Build ##{build_number}"
         # Check and see if the build is running
         is_building = @client.api_get_request(
-          "/job/#{job_name}/#{build_number}"
+          "/job/#{path_encode job_name}/#{build_number}"
         )["building"]
         if is_building
-          @client.api_post_request("/job/#{job_name}/#{build_number}/stop")
+          @client.api_post_request("/job/#{path_encode job_name}/#{build_number}/stop")
         end
       end
       alias_method :stop, :stop_build
@@ -515,7 +518,7 @@ module JenkinsApi
         else
           raise "Mode should either be 'text' or 'html'. You gave: #{mode}"
         end
-        get_msg = "/job/#{job_name}/#{build_num}/logText/progressive#{mode}?"
+        get_msg = "/job/#{path_encode job_name}/#{build_num}/logText/progressive#{mode}?"
         get_msg << "start=#{start}"
         raw_response = true
         api_response = @client.api_get_request(get_msg, nil, nil, raw_response)
@@ -610,7 +613,7 @@ module JenkinsApi
       #
       def list_details(job_name)
         @logger.info "Obtaining the details of '#{job_name}'"
-        @client.api_get_request("/job/#{job_name}")
+        @client.api_get_request("/job/#{path_encode job_name}")
       end
 
       # List upstream projects of a specific job
@@ -620,7 +623,7 @@ module JenkinsApi
       #
       def get_upstream_projects(job_name)
         @logger.info "Obtaining the upstream projects of '#{job_name}'"
-        response_json = @client.api_get_request("/job/#{job_name}")
+        response_json = @client.api_get_request("/job/#{path_encode job_name}")
         response_json["upstreamProjects"]
       end
 
@@ -631,7 +634,7 @@ module JenkinsApi
       #
       def get_downstream_projects(job_name)
         @logger.info "Obtaining the down stream projects of '#{job_name}'"
-        response_json = @client.api_get_request("/job/#{job_name}")
+        response_json = @client.api_get_request("/job/#{path_encode job_name}")
         response_json["downstreamProjects"]
       end
 
@@ -641,7 +644,7 @@ module JenkinsApi
       #
       def get_builds(job_name)
         @logger.info "Obtaining the build details of '#{job_name}'"
-        response_json = @client.api_get_request("/job/#{job_name}")
+        response_json = @client.api_get_request("/job/#{path_encode job_name}")
         response_json["builds"]
       end
 
@@ -683,7 +686,7 @@ module JenkinsApi
       #
       def get_current_build_status(job_name)
         @logger.info "Obtaining the current build status of '#{job_name}'"
-        response_json = @client.api_get_request("/job/#{job_name}")
+        response_json = @client.api_get_request("/job/#{path_encode job_name}")
         color_to_status(response_json["color"])
       end
       alias_method :status, :get_current_build_status
@@ -697,7 +700,7 @@ module JenkinsApi
       #
       def get_current_build_number(job_name)
         @logger.info "Obtaining the current build number of '#{job_name}'"
-        @client.api_get_request("/job/#{job_name}")['nextBuildNumber'].to_i - 1
+        @client.api_get_request("/job/#{path_encode job_name}")['nextBuildNumber'].to_i - 1
       end
       alias_method :build_number, :get_current_build_number
 
@@ -723,7 +726,7 @@ module JenkinsApi
         build_endpoint = params.empty? ? "build" : "buildWithParameters"
         raw_response = return_build_number
         response =@client.api_post_request(
-          "/job/#{job_name}/#{build_endpoint}",
+          "/job/#{path_encode job_name}/#{build_endpoint}",
           params,
           raw_response
         )
@@ -779,7 +782,7 @@ module JenkinsApi
       #
       def disable(job_name)
         @logger.info "Disabling job '#{job_name}'"
-        @client.api_post_request("/job/#{job_name}/disable")
+        @client.api_post_request("/job/#{path_encode job_name}/disable")
       end
 
       # Obtain the configuration stored in config.xml of a specific job
@@ -790,7 +793,7 @@ module JenkinsApi
       #
       def get_config(job_name)
         @logger.info "Obtaining the config.xml of '#{job_name}'"
-        @client.get_config("/job/#{job_name}")
+        @client.get_config("/job/#{path_encode job_name}")
       end
 
       # Post the configuration of a job given the job name and the config.xml
@@ -802,7 +805,7 @@ module JenkinsApi
       #
       def post_config(job_name, xml)
         @logger.info "Posting the config.xml of '#{job_name}'"
-        @client.post_config("/job/#{job_name}/config.xml", xml)
+        @client.post_config("/job/#{path_encode job_name}/config.xml", xml)
       end
 
       # Obtain the test results for a specific build of a job
@@ -814,7 +817,7 @@ module JenkinsApi
         build_num = get_current_build_number(job_name) if build_num == 0
         @logger.info "Obtaining the test results of '#{job_name}'" +
           " Build ##{build_num}"
-        @client.api_get_request("/job/#{job_name}/#{build_num}/testReport")
+        @client.api_get_request("/job/#{path_encode job_name}/#{build_num}/testReport")
       rescue Exceptions::NotFound
         # Not found is acceptable, as not all builds will have test results
         # and this is what jenkins throws at us in that case
@@ -831,7 +834,7 @@ module JenkinsApi
         @logger.info "Obtaining the build details of '#{job_name}'" +
           " Build ##{build_num}"
 
-        @client.api_get_request("/job/#{job_name}/#{build_num}/")
+        @client.api_get_request("/job/#{path_encode job_name}/#{build_num}/")
       end
 
       # Change the description of a specific job

--- a/lib/jenkins_api_client/urihelper.rb
+++ b/lib/jenkins_api_client/urihelper.rb
@@ -1,0 +1,17 @@
+require 'uri'
+
+module JenkinsApi
+  module UriHelper
+    # Encode a string for using in the query part of an URL
+    #
+    def form_encode(string)
+      URI.encode_www_form_component string.encode(Encoding::UTF_8)
+    end
+
+    # Encode a string for use in the hiearchical part of an URL
+    #
+    def path_encode(path)
+      URI.escape(path.encode(Encoding::UTF_8))
+    end
+  end
+end

--- a/lib/jenkins_api_client/view.rb
+++ b/lib/jenkins_api_client/view.rb
@@ -20,6 +20,8 @@
 # THE SOFTWARE.
 #
 
+require 'jenkins_api_client/urihelper'
+
 module JenkinsApi
   class Client
     # This class communicates with Jenkins "/view" API and used to create,
@@ -27,6 +29,7 @@ module JenkinsApi
     # API.
     #
     class View
+      include JenkinsApi::UriHelper
 
       # Initializes a new view object
       #
@@ -150,7 +153,7 @@ module JenkinsApi
         post_params.merge!("filterExecutors" => "on") if params[:filter_executors]
         post_params.merge!("useincluderegex" => "on",
                            "includeRegex" => params[:regex]) if params[:regex]
-        @client.api_post_request("/view/#{params[:name]}/configSubmit",
+        @client.api_post_request("/view/#{path_encode params[:name]}/configSubmit",
                                  post_params)
       end
 
@@ -160,7 +163,7 @@ module JenkinsApi
       #
       def delete(view_name)
         @logger.info "Deleting view '#{view_name}'"
-        @client.api_post_request("/view/#{view_name}/doDelete")
+        @client.api_post_request("/view/#{path_encode view_name}/doDelete")
       end
 
       # Deletes all views (except the All view) in Jenkins.
@@ -211,7 +214,7 @@ module JenkinsApi
         job_names = []
         raise "The view #{view_name} doesn't exists on the server"\
           unless exists?(view_name)
-        response_json = @client.api_get_request("/view/#{view_name}")
+        response_json = @client.api_get_request("/view/#{path_encode view_name}")
         response_json["jobs"].each do |job|
           job_names << job["name"]
         end
@@ -225,7 +228,7 @@ module JenkinsApi
       #
       def add_job(view_name, job_name)
         @logger.info "Adding job '#{job_name}' to view '#{view_name}'"
-        post_msg = "/view/#{view_name}/addJobToView?name=#{job_name}"
+        post_msg = "/view/#{path_encode view_name}/addJobToView?name=#{form_encode job_name}"
         @client.api_post_request(post_msg)
       end
 
@@ -236,7 +239,7 @@ module JenkinsApi
       #
       def remove_job(view_name, job_name)
         @logger.info "Removing job '#{job_name}' from view '#{view_name}'"
-        post_msg = "/view/#{view_name}/removeJobFromView?name=#{job_name}"
+        post_msg = "/view/#{path_encode view_name}/removeJobFromView?name=#{form_encode job_name}"
         @client.api_post_request(post_msg)
       end
 
@@ -246,7 +249,7 @@ module JenkinsApi
       #
       def get_config(view_name)
         @logger.info "Obtaining the configuration of view '#{view_name}'"
-        @client.get_config("/view/#{view_name}")
+        @client.get_config("/view/#{path_encode view_name}")
       end
 
       # Post the configuration of a view given the view name and the config.xml
@@ -256,7 +259,7 @@ module JenkinsApi
       #
       def post_config(view_name, xml)
         @logger.info "Posting the configuration of view '#{view_name}'"
-        @client.post_config("/view/#{view_name}/config.xml", xml)
+        @client.post_config("/view/#{path_encode view_name}/config.xml", xml)
       end
 
     end


### PR DESCRIPTION
New version of URI escaping that actually works. I agree it would be better to keep this logic in client.rb, but that is not possible, since view.rb and job.rb deal with URI already. A problem is that the parts needs to be escape differently depending on whether they are part of the URI path or the URI query.

To truly fix this in client, everything would need to be refactored to keep URI formatting out of job.rb/view.rb/etc.

This commit fixes
- Correct escaping of +/spaces in query path using URI.encode_www_form_component
- Correct escape of paths (e.g. unicode chars) using URI.escape
- Automatic conversion to UTF-8 character set
