### PR TITLE
Method to get promotions of given job

### DIFF
--- a/lib/jenkins_api_client/job.rb
+++ b/lib/jenkins_api_client/job.rb
@@ -1207,6 +1207,31 @@ module JenkinsApi
         filtered_job_names[0..parallel-1]
       end
 
+      # Get a list of promoted builds for given job
+      #
+      # @param  [String] job_name
+      # @return [Hash]   Hash map of promitions and the promoted builds. Promotions that didn't took place yet
+      #                  return nil
+      def get_promotions(job_name)
+        result = {}
+
+        @logger.info "Obtaining the promotions of '#{job_name}'"
+        response_json = @client.api_get_request("/job/#{job_name}/promotion")
+
+        response_json["processes"].each do |promotion|
+          @logger.info "Getting promotion details of '#{promotion['name']}'"
+
+          if promotion['color'] == 'notbuilt'
+            result[promotion['name']] = nil
+          else
+            promo_json = @client.api_get_request("/job/#{job_name}/promotion/latest/#{promotion['name']}")
+            result[promotion['name']] = promo_json['target']['number']
+          end
+        end
+
+        result
+      end
+
       private
 
       # Obtains the threshold params used by jenkins in the XML file

--- a/spec/unit_tests/job_spec.rb
+++ b/spec/unit_tests/job_spec.rb
@@ -515,6 +515,25 @@ describe JenkinsApi::Client::Job do
         end
       end
 
+      describe "#get_promotions" do
+        it "accepts the jon name and returns the promotions" do
+            mock_job_promotions_response = {
+              "processes" => [ { "name"  => "dev",
+                                 "url"   => "not_required",
+                                 "color" => "blue",
+                               },
+                               { "name"  => "stage",
+                                 "url"   => "not_required",
+                                 "color" => "notbuilt",
+                               },
+                             ], }
+
+          @client.should_receive(:api_get_request).with('/job/test_job/promotion').and_return(
+            mock_job_promotions_response)
+          @client.should_receive(:api_get_request).and_return({'target' => {'number' => 42}})
+          @job.get_promotions("test_job").should == {'dev' => 42, 'stage' => nil}
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Hi,

This PR implements rudimentary support for promoted builds (https://wiki.jenkins-ci.org/display/JENKINS/Promoted+Builds+Plugin). New job method #get_promotions returns a hash with promotion processes and the promoted build numbers.

Cheers!
Daniel
