### PR TITLE
Add the ability to execute groovy script on the Jenkins server

### DIFF
--- a/lib/jenkins_api_client/client.rb
+++ b/lib/jenkins_api_client/client.rb
@@ -537,6 +537,22 @@ module JenkinsApi
       response["Date"]
     end
 
+    # Executes the provided groovy script on the Jenkins CI server
+    #
+    # @param [String] script_text The text of the groovy script to execute
+    #
+    # @return [String] The output of the executed groovy script
+    #
+    def exec_script(script_text)
+      url = URI.escape("#{@jenkins_path}/scriptText")
+      request = Net::HTTP::Post.new("#{url}")
+      request.form_data = { 'script' =>  script_text }
+      @logger.info "POST #{url}"
+
+      response = make_http_request(request)
+      handle_exception(response, 'body')
+    end
+
     # Execute the Jenkins CLI
     #
     # @param command [String] command name

--- a/spec/func_tests/client_spec.rb
+++ b/spec/func_tests/client_spec.rb
@@ -65,6 +65,12 @@ describe JenkinsApi::Client do
           @client.get_hudson_version.class.should == String
         end
       end
+
+      describe "#exec_script" do
+        it "Should execute the provided groovy script" do
+          @client.exec_script('println("hi")').should == "hi\n"
+        end
+      end
     end
 
     describe "SubClassAccessorMethods" do

--- a/spec/unit_tests/client_spec.rb
+++ b/spec/unit_tests/client_spec.rb
@@ -218,6 +218,13 @@ describe JenkinsApi::Client do
         end
       end
 
+      describe "#exec_script" do
+        it "is defined and should accept script to execute" do
+          @client.respond_to?(:exec_script).should be_true
+          @client.method(:exec_script).parameters.size.should == 1
+        end
+      end
+
       describe "#exec_cli" do
         it "is defined and should execute the CLI" do
           @client.respond_to?(:exec_cli).should be_true


### PR DESCRIPTION
We make pretty extensive use of the API client but we've found a few instances where we need to directly execute groovy script on the server for efficiency or for out of the ordinary data retrieval.  Adding this method makes that easy.
