### PR TITLE
Can't create node

### DIFF
--- a/lib/jenkins_api_client/node.rb
+++ b/lib/jenkins_api_client/node.rb
@@ -113,6 +113,7 @@ module JenkinsApi
       #  * +:slave_host+ Hostname/IP of the slave
       #  * +:slave_port+ Slave port
       #  * +:private_key_file+ Private key file of master
+      #  * +:credentials_id+ Id for credential in Jenkins
       #
       # @example Create a Dump Slave
       #   create_dump_slave(
@@ -137,7 +138,9 @@ module JenkinsApi
           :remote_fs => "/var/jenkins",
           :labels => params[:name],
           :slave_port => 22,
-          :mode => "normal"
+          :mode => "normal",
+          :private_key_file => "",
+          :credentials_id => ""
         }
 
         params = default_params.merge(params)
@@ -167,6 +170,7 @@ module JenkinsApi
               "port" => params[:slave_port],
               "username" => params[:slave_user],
               "privatekey" => params[:private_key_file],
+              "credentialsId" => params[:credentials_id]
             }
           }.to_json
         }


### PR DESCRIPTION
Using LTS Jenkins ver. 1.532.1 installed by rpm on CentOS 6.4

jenkins_api_client.git on fa7a2ea

``` ruby
ruby scripts/login_with_irb.rb

puts @client.job.list(".*")

puts @client.node.create_dump_slave(
  :name => "slave1",
  :slave_host => "10.10.10.10",
  :private_key_file => "/root/.ssh/id_rsa",
  :executors => 10,
  :labels => "slave, ruby"
)
```

```
ruby scripts/login_with_irb.rb
logged-in to the Jenkins API, use the '@client' variable to use the client
irb(main):001:0> puts @client.job.list(".*")
I, [2014-02-06T15:18:16.314955 #47425]  INFO -- : Obtaining jobs matching filter '.*'
I, [2014-02-06T15:18:16.315061 #47425]  INFO -- : GET /api/json
whoami
=> nil
irb(main):002:0> puts @client.node.create_dump_slave(
irb(main):003:1*   :name => "slave1",
irb(main):004:1*   :slave_host => "10.10.10.10",
irb(main):005:1*   :private_key_file => "/root/.ssh/id_rsa",
irb(main):006:1*   :executors => 10,
irb(main):007:1*   :labels => "slave, ruby"
irb(main):008:1> )
I, [2014-02-06T15:18:22.079072 #47425]  INFO -- : Creating a dump slave 'slave1'
I, [2014-02-06T15:18:22.079319 #47425]  INFO -- : GET /api/json
I, [2014-02-06T15:18:22.085380 #47425]  INFO -- : POST /computer/doCreateItem
E, [2014-02-06T15:18:22.099554 #47425] ERROR -- : JenkinsApi::Exceptions::InternalServerError: Internel Server Error. Perhaps the in-memory configuration Jenkins is different from the disk configuration. Please try to reload the configuration
JenkinsApi::Exceptions::InternalServerError: Internel Server Error. Perhaps the in-memory configuration Jenkins is different from the disk configuration. Please try to reload the configuration
    from /Users/loa/workspace/github/jenkins_api_client/lib/jenkins_api_client/client.rb:721:in `handle_exception'
    from /Users/loa/workspace/github/jenkins_api_client/lib/jenkins_api_client/client.rb:351:in `api_post_request'
    from /Users/loa/workspace/github/jenkins_api_client/lib/jenkins_api_client/node.rb:175:in `create_dump_slave'
    from (irb):2
irb(main):009:0>
```
