### PR TITLE
don't set content type in api_post_request

### DIFF
--- a/lib/jenkins_api_client/client.rb
+++ b/lib/jenkins_api_client/client.rb
@@ -339,7 +339,6 @@ module JenkinsApi
         # that barf with empty post
         request = Net::HTTP::Post.new("#{@jenkins_path}#{url_prefix}")
         @logger.info "POST #{url_prefix}"
-        request.content_type = 'application/json'
         if @crumbs_enabled
           request[@crumb["crumbRequestField"]] = @crumb["crumb"]
         end


### PR DESCRIPTION
Since we call `request.set_form_data` we don't need to call `request.content_type` because `request.set_form_data` already sets the content_type to `application/x-www-form-urlencoded`, thus overwriting the `application/json` that was previously set.
