### PR TITLE
make exec_script use api_post_reqeust

### DIFF
--- a/lib/jenkins_api_client/client.rb
+++ b/lib/jenkins_api_client/client.rb
@@ -544,13 +544,8 @@ module JenkinsApi
     # @return [String] The output of the executed groovy script
     #
     def exec_script(script_text)
-      url = URI.escape("#{@jenkins_path}/scriptText")
-      request = Net::HTTP::Post.new("#{url}")
-      request.form_data = { 'script' =>  script_text }
-      @logger.info "POST #{url}"
-
-      response = make_http_request(request)
-      handle_exception(response, 'body')
+      response = api_post_request('/scriptText', {'script' => script_text}, true)
+      response.body
     end
 
     # Execute the Jenkins CLI


### PR DESCRIPTION
By having `exec_script` use `api_post_request` instead of directly making the call to `make_http_request` we allow `exec_script` to make use of _crumbs_ if they're enabled without having to write extra code for it.
