### PR TITLE
Prevent warnings due to Hash#[] call with nil items

### DIFF
--- a/lib/jenkins_api_client/plugin_manager.rb
+++ b/lib/jenkins_api_client/plugin_manager.rb
@@ -123,7 +123,7 @@ module JenkinsApi
           if filters.keys.all? { |key| plugin[key.to_s] == filters[key] }
             [plugin["shortName"], plugin["version"]]
           end
-        end]
+        end.compact]
         installed
       end
 


### PR DESCRIPTION
When `filters.keys.all? { |key| plugin[key.to_s] == filters[key] }` returns false in PluginManager#list_installed, Hash#[] would be called with some nil items like the following code `Hash[ [1,2], nil, [3,4] ]`, and this triggers warnings on Ruby 2.x. This patch prevents these warnings.

```
tmp.rb:1: warning: wrong element type nil at 1 (expected array)
tmp.rb:1: warning: ignoring wrong elements is deprecated, remove them explicitly
tmp.rb:1: warning: this causes ArgumentError in the next release
```
