### PR TITLE
Add require yaml in cli helper

### DIFF
--- a/lib/jenkins_api_client/cli/helper.rb
+++ b/lib/jenkins_api_client/cli/helper.rb
@@ -21,6 +21,7 @@
 #
 
 require 'fileutils'
+require 'yaml'
 
 module JenkinsApi
   module CLI


### PR DESCRIPTION
I tried to read credential info from yaml file using `jenkinscli` command and got the error below. I used ruby 2.1.0.

``` ruby
uninitialized constant JenkinsApi::CLI::Helper::YAML (NameError)
```

This patch helps me avoid this error.
