### PR TITLE
Fix get_details to compare against task_name

### DIFF
--- a/lib/jenkins_api_client/build_queue.rb
+++ b/lib/jenkins_api_client/build_queue.rb
@@ -94,7 +94,7 @@ module JenkinsApi
         response_json = @client.api_get_request("/queue")
         details = {}
         response_json["items"].each do |item|
-          details = item if item["task"]["name"]
+          details = item if item["task"]["name"] == task_name
         end
         details
       end


### PR DESCRIPTION
Current implementation of get_details never compares against task_name and so it just always returns details for the last item in the queue.
