### PR TITLE
Make Client::Job.build only request current build number if passed build_start_timeout option.

### DIFF
--- a/lib/jenkins_api_client/job.rb
+++ b/lib/jenkins_api_client/job.rb
@@ -772,11 +772,13 @@ module JenkinsApi
         msg << " with parameters: #{params.inspect}" unless params.empty?
         @logger.info msg
 
-        # Best-guess build-id
-        # This is only used if we go the old-way below... but we can use this number to detect if multiple
-        # builds were queued
-        current_build_id = get_current_build_number(job_name)
-        expected_build_id = current_build_id > 0 ? current_build_id + 1 : 1
+        if (opts['build_start_timeout'] || 0) > 0
+          # Best-guess build-id
+          # This is only used if we go the old-way below... but we can use this number to detect if multiple
+          # builds were queued
+          current_build_id = get_current_build_number(job_name)
+          expected_build_id = current_build_id > 0 ? current_build_id + 1 : 1
+        end
 
         if (params.nil? or params.empty?)
           response = @client.api_post_request("/job/#{path_encode job_name}/build",

--- a/spec/unit_tests/job_spec.rb
+++ b/spec/unit_tests/job_spec.rb
@@ -383,15 +383,11 @@ describe JenkinsApi::Client::Job do
       describe "#build" do
         # First tests confirm the build method works the same as it used to
         it "accepts the job name and builds the job" do
-          @client.should_receive(:api_get_request).with(
-            "/job/test_job").and_return({})
           @client.should_receive(:api_post_request).with(
             "/job/test_job/build", {}, true).and_return(FakeResponse.new(302))
           @job.build("test_job").should == '302'
         end
         it "accepts the job name with params and builds the job" do
-          @client.should_receive(:api_get_request).with(
-            "/job/test_job").and_return({})
           @client.should_receive(:api_post_request).with(
             "/job/test_job/buildWithParameters",
             {:branch => 'feature/new-stuff'},


### PR DESCRIPTION
It didn't seem like there was any reason to make an additional HTTP request if the caller doesn't care what the new build id is.
