### PR TITLE
NoTask - Created Config CLI subcommand and added to existing CLI

### DIFF
--- a/jenkins_api_client.gemspec
+++ b/jenkins_api_client.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |s|
     "lib/jenkins_api_client.rb",
     "lib/jenkins_api_client/build_queue.rb",
     "lib/jenkins_api_client/cli/base.rb",
+    "lib/jenkins_api_client/cli/config.rb",
     "lib/jenkins_api_client/cli/helper.rb",
     "lib/jenkins_api_client/cli/job.rb",
     "lib/jenkins_api_client/cli/node.rb",

--- a/lib/jenkins_api_client/cli/base.rb
+++ b/lib/jenkins_api_client/cli/base.rb
@@ -22,8 +22,9 @@
 
 require 'thor'
 require 'thor/group'
-require "#{File.dirname(__FILE__)}/node.rb"
+require "#{File.dirname(__FILE__)}/config.rb"
 require "#{File.dirname(__FILE__)}/job.rb"
+require "#{File.dirname(__FILE__)}/node.rb"
 require "#{File.dirname(__FILE__)}/system.rb"
 
 module JenkinsApi
@@ -77,6 +78,14 @@ module JenkinsApi
         'system',
         'system [subcommand]',
         'Provides functions to access system functions of the Jenkins CI server'
+      )
+
+      # Register the CLI::Config class as "config" subcommand to CLI
+      register(
+        CLI::Config,
+        'config',
+        'config [subcommand]',
+        'Provides functions to read and write credentials to the login.yml'
       )
 
     end

--- a/lib/jenkins_api_client/cli/config.rb
+++ b/lib/jenkins_api_client/cli/config.rb
@@ -1,0 +1,48 @@
+require 'thor'
+require 'thor/group'
+
+module JenkinsApi
+  module CLI
+    # This class provides various command line operations related to the credentials configuration.
+    class Config < Thor
+      include Thor::Actions
+
+      desc "list", "List credentials"
+      # CLI command to list the current login.yml credentials
+      def list
+        if File.exist?("#{ENV['HOME']}/.jenkins_api_client/login.yml")
+          creds = YAML.load_file(
+            File.expand_path(
+              "#{ENV['HOME']}/.jenkins_api_client/login.yml", __FILE__
+            )
+          )
+          creds.each { |key, value| puts "#{key}: #{value}" }
+        else
+          puts "login.yml file does not exist"
+          exit 1
+        end
+      end
+
+      desc "add", "Add new credentials to the login.yml file"
+      # CLI command that creates and adds the creds to the login.yml file
+      def add
+        if parent_options[:username] && parent_options[:server_ip] && \
+          (parent_options[:password] || parent_options[:password_base64])
+          creds = parent_options
+        elsif parent_options[:creds_file]
+          creds = YAML.load_file(
+            File.expand_path(parent_options[:creds_file], __FILE__)
+          )
+        else
+          msg = "Credentials are not set. Please pass them as parameters or"
+          msg << " set them in a credentials file"
+          puts msg
+          exit 1
+        end
+
+        FileUtils.mkdir_p("#{ENV['HOME']}/.jenkins_api_client")
+        File.open("#{ENV['HOME']}/.jenkins_api_client/login.yml", 'w') { |f| YAML.dump(creds, f) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Attempt 2, apologies for the previous PR

As in previous the PR
I had an idea as to something that would make creating a credentials config file easier for new users.
I have added a config subcommand that allows a user to read and write to the login.yml file

The two commands are:
jenkinscli config add - Adds the given credentials to the login.yml
```
$ jenkinscli config add -u name -p password -s 1.2.3.4
```

jenkinscli config list - Lists the current login.yml contents
```
$ jenkinscli config list
username: name
password: password
server_ip: 1.2.3.4
```