### PR TITLE
Fix job#build method when true/false values are passed as timeout parameter

### DIFF
--- a/lib/jenkins_api_client/job.rb
+++ b/lib/jenkins_api_client/job.rb
@@ -827,9 +827,9 @@ module JenkinsApi
       # @return [String] HTTP response code (per prev. behavior) (NO TIMEOUT SPECIFIED)
       #
       def build(job_name, params={}, opts = {})
-        if opts.nil? || opts.class.is_a?(FalseClass)
+        if opts.nil? || opts.is_a?(FalseClass)
           opts = {}
-        elsif opts.class.is_a?(TrueClass)
+        elsif opts.is_a?(TrueClass)
           opts = { 'build_start_timeout' => @client_timeout }
         end
 


### PR DESCRIPTION
Defect found few days ago. Only today I had a time to fix it and implement a few tests.
I didn't understand very well the test examples and how to better organize them. Please consider a time to review the strategy I took.