### PR TITLE
Passing tree= to View.list, use_crumbs?, use_security? to improve performance on large systems

### DIFF
--- a/lib/jenkins_api_client/client.rb
+++ b/lib/jenkins_api_client/client.rb
@@ -489,7 +489,7 @@ module JenkinsApi
     # @return [Boolean] whether Jenkins uses crumbs or not
     #
     def use_crumbs?
-      response = api_get_request("")
+      response = api_get_request("", "tree=useCrumbs")
       response["useCrumbs"]
     end
 
@@ -498,7 +498,7 @@ module JenkinsApi
     # @return [Boolean] whether Jenkins uses security or not
     #
     def use_security?
-      response = api_get_request("")
+      response = api_get_request("", "tree=useSecurity")
       response["useSecurity"]
     end
 

--- a/lib/jenkins_api_client/view.rb
+++ b/lib/jenkins_api_client/view.rb
@@ -184,7 +184,7 @@ module JenkinsApi
       def list(filter = "", ignorecase = true)
         @logger.info "Obtaining views based on filter '#{filter}'"
         view_names = []
-        response_json = @client.api_get_request("")
+        response_json = @client.api_get_request("", "tree=views[name]")
         response_json["views"].each { |view|
           if ignorecase
             view_names << view["name"] if view["name"] =~ /#{filter}/i

--- a/spec/unit_tests/client_spec.rb
+++ b/spec/unit_tests/client_spec.rb
@@ -319,6 +319,46 @@ describe JenkinsApi::Client do
           @client.compare_versions("1.0.10", "1.0.2").should eql(1)
         end
       end
+
+      describe "#use_crumbs?" do
+        it "returns true if the server has useCrumbs on" do
+          expect(@client).to receive(:api_get_request).with("", "tree=useCrumbs") {
+            {
+              "useCrumbs" => true
+            }
+          }
+          @client.use_crumbs?.should == true
+        end
+
+        it "returns false if the server has useCrumbs off" do
+          expect(@client).to receive(:api_get_request).with("", "tree=useCrumbs") {
+            {
+              "useCrumbs" => false
+            }
+          }
+          @client.use_crumbs?.should == false
+        end
+      end
+
+      describe "#use_security?" do
+        it "returns true if the server has useSecurity on" do
+          expect(@client).to receive(:api_get_request).with("", "tree=useSecurity") {
+            {
+              "useSecurity" => true
+            }
+          }
+          @client.use_security?.should == true
+        end
+
+        it "returns false if the server has useSecurity off" do
+          expect(@client).to receive(:api_get_request).with("", "tree=useSecurity") {
+            {
+              "useSecurity" => false
+            }
+          }
+          @client.use_security?.should == false
+        end
+      end
     end
   end
 

--- a/spec/unit_tests/view_spec.rb
+++ b/spec/unit_tests/view_spec.rb
@@ -23,7 +23,7 @@ describe JenkinsApi::Client::View do
 
     describe "InstanceMethods" do
       describe "#initialize" do
-        it "initializes by receiving an instane of client object" do
+        it "initializes by receiving an instance of client object" do
           mock_logger = Logger.new "/dev/null"
           @client.should_receive(:logger).and_return(mock_logger)
           expect(
@@ -48,21 +48,21 @@ describe JenkinsApi::Client::View do
 
       describe "#list" do
         it "lists all views" do
-          @client.should_receive(:api_get_request).with("").and_return(@sample_views_json)
+          @client.should_receive(:api_get_request).with("", "tree=views[name]").and_return(@sample_views_json)
           response = @view.list
           response.class.should == Array
           response.size.should == 2
         end
 
         it "lists views matching specific filter" do
-          @client.should_receive(:api_get_request).with("").and_return(@sample_views_json)
+          @client.should_receive(:api_get_request).with("", "tree=views[name]").and_return(@sample_views_json)
           response = @view.list("test_view2")
           response.class.should == Array
           response.size.should == 1
         end
 
         it "lists views matching specific filter and matches case" do
-          @client.should_receive(:api_get_request).with("").and_return(@sample_views_json)
+          @client.should_receive(:api_get_request).with("", "tree=views[name]").and_return(@sample_views_json)
           response = @view.list("TEST_VIEW", false)
           response.class.should == Array
           response.size.should == 0
@@ -71,19 +71,19 @@ describe JenkinsApi::Client::View do
 
       describe "#exists?" do
         it "returns true a view that exists" do
-          @client.should_receive(:api_get_request).with("").and_return(@sample_views_json)
+          @client.should_receive(:api_get_request).with("", "tree=views[name]").and_return(@sample_views_json)
           @view.exists?("test_view2").should == true
         end
 
         it "returns false for non-existent view" do
-          @client.should_receive(:api_get_request).with("").and_return(@sample_views_json)
+          @client.should_receive(:api_get_request).with("", "tree=views[name]").and_return(@sample_views_json)
           @view.exists?("i_am_not_there").should == false
         end
       end
 
       describe "#list_jobs" do
         it "lists all jobs in the given view" do
-          @client.should_receive(:api_get_request).with("").and_return(@sample_views_json)
+          @client.should_receive(:api_get_request).with("", "tree=views[name]").and_return(@sample_views_json)
           @client.should_receive(:api_get_request).with("/view/test_view").and_return(@sample_view_json)
           response = @view.list_jobs("test_view")
           response.class.should == Array
@@ -91,7 +91,7 @@ describe JenkinsApi::Client::View do
         end
 
         it "raises an error if called on a non-existent view" do
-          @client.should_receive(:api_get_request).with("").and_return(@sample_views_json)
+          @client.should_receive(:api_get_request).with("", "tree=views[name]").and_return(@sample_views_json)
           expect(
             lambda { @view.list_jobs("i_am_not_there") }
           ).to raise_error


### PR DESCRIPTION
We have Jenkins instances in the 10s of thousands of jobs.  Loading `{root}/api/json` can take a while.

I found three calls that are currently loading that URL, `View.list`, `Client.use_crumbs?`, and `Client.use_security?`.

Instead, of loading everything, you could use the `?tree=` feature to load just the value you are looking for.  This is related to #89.