### PR TITLE
Added ability to pass "tree" parameter to the Job#get_buils call.

### DIFF
--- a/lib/jenkins_api_client/job.rb
+++ b/lib/jenkins_api_client/job.rb
@@ -716,12 +716,7 @@ module JenkinsApi
         @logger.info "Obtaining the build details of '#{job_name}'"
         url = "/job/#{path_encode job_name}"
 
-        tree_string = nil
-        if tree
-          tree_string = "tree=#{tree}"
-        end
-
-        response_json = @client.api_get_request url, tree_string
+        response_json = @client.api_get_request url, tree_string(tree)
         response_json["builds"]
       end
 
@@ -1747,6 +1742,11 @@ module JenkinsApi
             xml.color "#{color}"
           }
         }
+      end
+
+      def tree_string tree_value
+        return nil unless tree_value
+        "tree=#{tree_value}"
       end
     end
   end

--- a/lib/jenkins_api_client/job.rb
+++ b/lib/jenkins_api_client/job.rb
@@ -712,10 +712,11 @@ module JenkinsApi
       #
       # @param [String] job_name
       #
-      def get_builds(job_name, tree: nil)
+      def get_builds(job_name, options = {})
         @logger.info "Obtaining the build details of '#{job_name}'"
         url = "/job/#{path_encode job_name}"
 
+        tree = options[:tree] || nil
         response_json = @client.api_get_request url, tree_string(tree)
         response_json["builds"]
       end

--- a/lib/jenkins_api_client/job.rb
+++ b/lib/jenkins_api_client/job.rb
@@ -712,9 +712,16 @@ module JenkinsApi
       #
       # @param [String] job_name
       #
-      def get_builds(job_name)
+      def get_builds(job_name, tree: nil)
         @logger.info "Obtaining the build details of '#{job_name}'"
-        response_json = @client.api_get_request("/job/#{path_encode job_name}")
+        url = "/job/#{path_encode job_name}"
+
+        tree_string = nil
+        if tree
+          tree_string = "tree=#{tree}"
+        end
+
+        response_json = @client.api_get_request url, tree_string
         response_json["builds"]
       end
 


### PR DESCRIPTION
By default, get_builds does not return such information as build duration and parameters. It's nice to have a possibility to configure which data exactly should be fetched from Jenkins.

api_get_request already has an optional tree parameter which can be used for this purpose.