### PR TITLE
Use the specified client ssl when downloading artifacts

### DIFF
--- a/lib/jenkins_api_client/client.rb
+++ b/lib/jenkins_api_client/client.rb
@@ -268,7 +268,7 @@ module JenkinsApi
       uri = URI.parse(@artifact)
       http = Net::HTTP.new(uri.host, uri.port)
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-      http.use_ssl = true
+      http.use_ssl = @ssl
       request = Net::HTTP::Get.new(uri.request_uri)
       request.basic_auth(@username, @password)
       response = http.request(request)


### PR DESCRIPTION
If your jenkins doesn't have SSL enabled, you can't download artifacts with this option always set to true. 