### PR TITLE
Fixing #59: Adding feature to toggle temporilyOffline status of Node

### DIFF
--- a/lib/jenkins_api_client/client.rb
+++ b/lib/jenkins_api_client/client.rb
@@ -371,6 +371,8 @@ module JenkinsApi
     #
     # @param [String] url_prefix The prefix to be used in the URL
     # @param [Hash] form_data Form data to send with POST request
+    # @param [Boolean] raw_response Return complete Response object instead of
+    #   JSON body of response
     #
     # @return [String] Response code form Jenkins Response
     #

--- a/lib/jenkins_api_client/node.rb
+++ b/lib/jenkins_api_client/node.rb
@@ -306,6 +306,22 @@ module JenkinsApi
         @client.post_config("/computer/#{path_encode node_name}/config.xml", xml)
       end
 
+      # Toggles the temporarily offline state of the Jenkins node
+      #
+      # @param [String] node_name name of the node
+      # @param [String] reason Offline reason why the node is offline
+      #
+      def toggle_temporarilyOffline(node_name, reason="")
+        @logger.info "Toggling the temporarily offline status of of node '#{node_name}' with reason '#{reason}'"
+        node_name = "(master)" if node_name == "master"
+        previous_state = is_temporarilyOffline?(node_name)
+        @client.api_post_request("/computer/#{path_encode node_name}/toggleOffline?offlineMessage=#{path_encode reason}")
+        new_state = is_temporarilyOffline?(node_name)
+        if new_state == previous_state
+          raise "The specified node '#{node_name}' was unable to change offline state."
+        end
+        new_state
+      end
     end
   end
 end


### PR DESCRIPTION
Could fix #59 

Since this is poorly documented on Jenkin's side, I stole this from Python API: https://github.com/salimfadhley/jenkinsapi/blob/7aebbf545e9f24fd33c672eef885a2f8029458a9/jenkinsapi/node.py#L98-L123