### PR TITLE
Use FalseClass to test whether a node is returning false for node properties

### DIFF
--- a/lib/jenkins_api_client/node.rb
+++ b/lib/jenkins_api_client/node.rb
@@ -257,7 +257,7 @@ module JenkinsApi
           node_name = "(master)" if node_name == "master"
           response_json = @client.api_get_request("/computer/#{path_encode node_name}", "tree=#{path_encode meth_suffix}")
           resp = response_json["#{meth_suffix}"].to_s
-          resp =~ /False/i ? false : true
+          resp.is_a?(FalseClass) ? false : true
         end
       end
 


### PR DESCRIPTION
When checking whether a node is idle, we are always returning true.
The JSON is returning 
```ruby
{"executors"=>[{}, {}],
"icon"=>"computer.png",
"iconClassName"=>"icon-computer",
"idle"=>false,
"jnlpAgent"=>true,
"launchSupported"=>false}
```
We still get
```bash
I, [2015-06-12T12:50:15.617773 #8857]  INFO -- : Obtaining 'idle' property of 'xxx.dev.rapid7.com'
 => true
```

This is due to the value being a FalseClass, not a "false" string.

This pull request repairs the isIdle behavior. This should work for all other node properties as well. 