### PR TITLE
Adding root 'functionality' to get information available at Jenkins root URL

### DIFF
--- a/jenkins_api_client.gemspec
+++ b/jenkins_api_client.gemspec
@@ -50,6 +50,7 @@ Gem::Specification.new do |s|
     "lib/jenkins_api_client/system.rb",
     "lib/jenkins_api_client/urihelper.rb",
     "lib/jenkins_api_client/user.rb",
+    "lib/jenkins_api_client/root.rb",
     "lib/jenkins_api_client/version.rb",
     "lib/jenkins_api_client/view.rb",
     "scripts/login_with_irb.rb",

--- a/lib/jenkins_api_client.rb
+++ b/lib/jenkins_api_client.rb
@@ -30,6 +30,7 @@ require 'jenkins_api_client/view'
 require 'jenkins_api_client/build_queue'
 require 'jenkins_api_client/plugin_manager'
 require 'jenkins_api_client/user'
+require 'jenkins_api_client/root'
 
 require 'jenkins_api_client/cli/helper'
 require 'jenkins_api_client/cli/base'

--- a/lib/jenkins_api_client/client.rb
+++ b/lib/jenkins_api_client/client.rb
@@ -233,6 +233,14 @@ module JenkinsApi
       JenkinsApi::Client::User.new(self)
     end
 
+    # Creates an instance of the Root class by passing a reference to self
+    #
+    # @return [JenkinsApi::Client::Root] An object of Root subclass
+    #
+    def root
+      JenkinsApi::Client::Root.new(self)
+    end
+
     # Returns a string representing the class name
     #
     # @return [String] string representation of class name

--- a/lib/jenkins_api_client/root.rb
+++ b/lib/jenkins_api_client/root.rb
@@ -1,0 +1,69 @@
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+require 'jenkins_api_client/urihelper'
+
+module JenkinsApi
+  class Client
+    # This class communicates with Jenkins API at the root address to obtain details
+    # on the page displayed to users on the Jenkins' 'homepage,' and other
+    # data items such as quietingDown
+    class Root
+      include JenkinsApi::UriHelper
+
+      # Initializes a new root object
+      #
+      # @param client [Client] the client object
+      #
+      # @return [Root] the root object
+      #
+      def initialize(client)
+        @client = client
+        @logger = @client.logger
+      end
+
+      # Return a string representation of the object
+      #
+      def to_s
+        "#<JenkinsApi::Client::Root>"
+      end
+
+      # Check if Jenkins is in shutdown mode
+      #
+      # @return [Boolean] true if server in shutdown mode
+      #
+      def quieting_down?
+        response_json = @client.api_get_request ("")
+        !response_json.nil? && response_json['quietingDown'] == 'true'
+      end
+
+      # Get message displayed to users on the homepage
+      #
+      # @return [String] description - message displayed to users
+      #
+      def description
+        response_json = @client.api_get_request ("")
+        if !response_json.nil?
+          response_json['description']
+        end
+      end
+    end
+  end
+end

--- a/lib/jenkins_api_client/root.rb
+++ b/lib/jenkins_api_client/root.rb
@@ -51,7 +51,7 @@ module JenkinsApi
       #
       def quieting_down?
         response_json = @client.api_get_request ("")
-        !response_json.nil? && response_json['quietingDown'] == 'true'
+        response_json['quietingDown']
       end
 
       # Get message displayed to users on the homepage
@@ -60,9 +60,7 @@ module JenkinsApi
       #
       def description
         response_json = @client.api_get_request ("")
-        if !response_json.nil?
-          response_json['description']
-        end
+        response_json['description']
       end
     end
   end

--- a/lib/jenkins_api_client/root.rb
+++ b/lib/jenkins_api_client/root.rb
@@ -50,7 +50,7 @@ module JenkinsApi
       # @return [Boolean] true if server in shutdown mode
       #
       def quieting_down?
-        response_json = @client.api_get_request ("")
+        response_json = @client.api_get_request('', 'tree=quietingDown')
         response_json['quietingDown']
       end
 
@@ -59,7 +59,7 @@ module JenkinsApi
       # @return [String] description - message displayed to users
       #
       def description
-        response_json = @client.api_get_request ("")
+        response_json = @client.api_get_request('', 'tree=description')
         response_json['description']
       end
     end

--- a/lib/jenkins_api_client/system.rb
+++ b/lib/jenkins_api_client/system.rb
@@ -54,11 +54,18 @@ module JenkinsApi
         @client.api_post_request("/quietDown")
       end
 
-      # Cancels the quiet doen request sent to the server.
+      # Cancels the quiet down request sent to the server.
       #
       def cancel_quiet_down
         @logger.info "Cancelling jenkins form quiet down..."
         @client.api_post_request("/cancelQuietDown")
+      end
+
+      # Checks if server is in quiet down mode.
+      #
+      def check_quiet_down
+        @logger.info "Checking if jenkins is in quiet down mode..."
+        @client.quieting_down?
       end
 
       # Restarts the Jenkins server

--- a/lib/jenkins_api_client/system.rb
+++ b/lib/jenkins_api_client/system.rb
@@ -63,9 +63,9 @@ module JenkinsApi
 
       # Checks if server is in quiet down mode.
       #
-      def check_quiet_down
+      def check_quiet_down?
         @logger.info "Checking if jenkins is in quiet down mode..."
-        @client.quieting_down?
+        @client.root.quieting_down?
       end
 
       # Restarts the Jenkins server

--- a/spec/unit_tests/client_spec.rb
+++ b/spec/unit_tests/client_spec.rb
@@ -161,38 +161,50 @@ describe JenkinsApi::Client do
       end
     end
 
+    describe "#root" do
+      it "Should return a Client::Root object" do
+        client = JenkinsApi::Client.new(
+            :server_ip => '127.0.0.1',
+            :server_port => 8080,
+            :username => 'username',
+            :password => 'password'
+        )
+        client.root.class.should == JenkinsApi::Client::Root
+      end
+    end
+
     describe "InstanceMethods" do
       describe "#get_root" do
         it "is defined with no parameters" do
-          @client.respond_to?(:get_root).should be_true
+          @client.respond_to?(:get_root).should be true
           @client.method(:get_root).parameters.size.should == 0
         end
       end
 
       describe "#api_get_request" do
         it "defined and should accept url_prefix, tree, and url_suffix" do
-          @client.respond_to?(:api_get_request).should be_true
+          @client.respond_to?(:api_get_request).should be true
           @client.method(:api_get_request).parameters.size.should == 4
         end
       end
 
       describe "#api_post_request" do
         it "is defined and should accept url_prefix" do
-          @client.respond_to?(:api_post_request).should be_true
+          @client.respond_to?(:api_post_request).should be true
           @client.method(:api_post_request).parameters.size.should == 3
         end
       end
 
       describe "#get_config" do
         it "is defined and should accept url_prefix" do
-          @client.respond_to?(:get_config).should be_true
+          @client.respond_to?(:get_config).should be true
           @client.method(:get_config).parameters.size.should == 1
         end
       end
 
       describe "#post_config" do
         it "is defined and should accept url_prefix and xml" do
-          @client.respond_to?(:post_config).should be_true
+          @client.respond_to?(:post_config).should be true
           @client.method(:post_config).parameters.size.should == 2
         end
 
@@ -208,7 +220,7 @@ describe JenkinsApi::Client do
 
       describe "#post_json" do
         it "is defined and should accept url_prefix and json" do
-          @client.respond_to?(:post_json).should be_true
+          @client.respond_to?(:post_json).should be true
           @client.method(:post_json).parameters.size.should == 2
         end
 
@@ -224,42 +236,42 @@ describe JenkinsApi::Client do
 
       describe "#get_jenkins_version" do
         it "is defined and accepts no parameters" do
-          @client.respond_to?(:get_jenkins_version).should be_true
+          @client.respond_to?(:get_jenkins_version).should be true
           @client.method(:get_jenkins_version).parameters.size.should == 0
         end
       end
 
       describe "#get_hudson_version" do
         it "is defined and accepts no parameters" do
-          @client.respond_to?(:get_hudson_version).should be_true
+          @client.respond_to?(:get_hudson_version).should be true
           @client.method(:get_hudson_version).parameters.size.should == 0
         end
       end
 
       describe "#get_server_date" do
         it "is defined and accepts no parameters" do
-          @client.respond_to?(:get_server_date).should be_true
+          @client.respond_to?(:get_server_date).should be true
           @client.method(:get_server_date).parameters.size.should == 0
         end
       end
 
       describe "#exec_script" do
         it "is defined and should accept script to execute" do
-          @client.respond_to?(:exec_script).should be_true
+          @client.respond_to?(:exec_script).should be true
           @client.method(:exec_script).parameters.size.should == 1
         end
       end
 
       describe "#exec_cli" do
         it "is defined and should execute the CLI" do
-          @client.respond_to?(:exec_cli).should be_true
+          @client.respond_to?(:exec_cli).should be true
           @client.method(:exec_cli).parameters.size.should == 2
         end
       end
 
       describe "#deconstruct_version_string" do
         it "is defined and accepts a single param" do
-          @client.respond_to?(:deconstruct_version_string).should be_true
+          @client.respond_to?(:deconstruct_version_string).should be true
           @client.method(:deconstruct_version_string).parameters.size.should == 1
         end
 
@@ -301,7 +313,7 @@ describe JenkinsApi::Client do
 
       describe "#compare_versions" do
         it "is defined and accepts two params" do
-          @client.respond_to?(:compare_versions).should be_true
+          @client.respond_to?(:compare_versions).should be true
           @client.method(:compare_versions).parameters.size.should == 2
         end
 

--- a/spec/unit_tests/node_spec.rb
+++ b/spec/unit_tests/node_spec.rb
@@ -211,7 +211,7 @@ describe JenkinsApi::Client::Node do
           ).and_return(
             @offline_slave
           )
-          @node.method("is_offline?").call("slave").should be_true
+          @node.method("is_offline?").call("slave").should be true
         end
 
         it "returns false if the node is online" do
@@ -223,7 +223,7 @@ describe JenkinsApi::Client::Node do
           ).and_return(
             @online_slave
           )
-          @node.method("is_offline?").call("slave").should be_false
+          @node.method("is_offline?").call("slave").should be false
         end
 
         it "returns false if the node is online and have a string value on its attr" do
@@ -235,7 +235,7 @@ describe JenkinsApi::Client::Node do
           ).and_return(
             @offline_slave_in_string
           )
-          @node.method("is_offline?").call("slave").should be_true
+          @node.method("is_offline?").call("slave").should be true
         end
 
         it "returns false if the node is online and have a string value on its attr" do
@@ -247,7 +247,7 @@ describe JenkinsApi::Client::Node do
           ).and_return(
             @online_slave_in_string
           )
-          @node.method("is_offline?").call("slave").should be_false
+          @node.method("is_offline?").call("slave").should be false
         end
       end
 
@@ -314,7 +314,7 @@ describe JenkinsApi::Client::Node do
             @offline_slave,
             @online_slave
           )
-          @node.method("toggle_temporarilyOffline").call("slave", "foo bar").should be_false
+          @node.method("toggle_temporarilyOffline").call("slave", "foo bar").should be false
         end
 
         it "fails to toggle an offline status of a node" do

--- a/spec/unit_tests/root_spec.rb
+++ b/spec/unit_tests/root_spec.rb
@@ -35,19 +35,19 @@ describe JenkinsApi::Client::Root do
 
       describe "#quieting_down?" do
         it "returns false if jenkins is jenkins is not quieting down" do
-          allow(@client).to receive(:api_get_request).with("").and_return(@sample_root_json1)
+          allow(@client).to receive(:api_get_request).with('', 'tree=quietingDown').and_return(@sample_root_json1)
           expect @root.quieting_down?.should be false
         end
 
         it "returns true if jenkins quieting down" do
-          allow(@client).to receive(:api_get_request).with("").and_return(@sample_root_json2)
+          allow(@client).to receive(:api_get_request).with('', 'tree=quietingDown').and_return(@sample_root_json2)
           expect @root.quieting_down?.should be true
         end
       end
 
       describe "#description" do
         it "gets the message displayed to users on the home page" do
-          allow(@client).to receive(:api_get_request).with("").and_return(@sample_root_json1)
+          allow(@client).to receive(:api_get_request).with('', 'tree=description').and_return(@sample_root_json1)
           expect @root.description.should == "Hello Users"
         end
       end

--- a/spec/unit_tests/root_spec.rb
+++ b/spec/unit_tests/root_spec.rb
@@ -1,0 +1,56 @@
+require File.expand_path('../spec_helper', __FILE__)
+
+describe JenkinsApi::Client::Root do
+  context "With properly initialized Client" do
+    before do
+      mock_logger = Logger.new "/dev/null"
+      @client = double
+      @client.should_receive(:logger).and_return(mock_logger)
+      @root = JenkinsApi::Client::Root.new(@client)
+      @sample_root_json1 = {
+        "description" => "Hello Users",
+        "primaryView" => [
+            "name" => "default_view",
+            "url" => "http://buildsystem:9999/jenkins"
+        ],
+        "quietingDown" => "false",
+        "useCrumbs" => "true",
+        "useSecurity" => "true"
+      }
+      @sample_root_json2 = {
+        "quietingDown" => "true"
+      }
+    end
+
+    describe "InstanceMethods" do
+      describe "#initialize" do
+        it "initializes by receiving an instance of client object" do
+          mock_logger = Logger.new "/dev/null"
+          @client.should_receive(:logger).and_return(mock_logger)
+          expect(
+            lambda { JenkinsApi::Client::Root.new(@client) }
+          ).not_to raise_error
+        end
+      end
+
+      describe "#quieting_down?" do
+        it "returns false if jenkins is jenkins is not quieting down" do
+          allow(@client).to receive(:api_get_request).with("").and_return(@sample_root_json1)
+          expect @root.quieting_down?.should == false
+        end
+
+        it "returns true if jenkins quieting down" do
+          allow(@client).to receive(:api_get_request).with("").and_return(@sample_root_json2)
+          expect @root.quieting_down?.should == true
+        end
+      end
+
+      describe "#description" do
+        it "gets the message displayed to users on the home page" do
+          allow(@client).to receive(:api_get_request).with("").and_return(@sample_root_json1)
+          expect @root.description.should == "Hello Users"
+        end
+      end
+    end
+  end
+end

--- a/spec/unit_tests/root_spec.rb
+++ b/spec/unit_tests/root_spec.rb
@@ -13,12 +13,12 @@ describe JenkinsApi::Client::Root do
             "name" => "default_view",
             "url" => "http://buildsystem:9999/jenkins"
         ],
-        "quietingDown" => "false",
+        "quietingDown" => false,
         "useCrumbs" => "true",
         "useSecurity" => "true"
       }
       @sample_root_json2 = {
-        "quietingDown" => "true"
+        "quietingDown" => true
       }
     end
 
@@ -36,12 +36,12 @@ describe JenkinsApi::Client::Root do
       describe "#quieting_down?" do
         it "returns false if jenkins is jenkins is not quieting down" do
           allow(@client).to receive(:api_get_request).with("").and_return(@sample_root_json1)
-          expect @root.quieting_down?.should == false
+          expect @root.quieting_down?.should be false
         end
 
         it "returns true if jenkins quieting down" do
           allow(@client).to receive(:api_get_request).with("").and_return(@sample_root_json2)
-          expect @root.quieting_down?.should == true
+          expect @root.quieting_down?.should be true
         end
       end
 

--- a/spec/unit_tests/system_spec.rb
+++ b/spec/unit_tests/system_spec.rb
@@ -39,6 +39,13 @@ describe JenkinsApi::Client::System do
         end
       end
 
+      describe "#check_quiet_down" do
+        it "checks if the server is presently in quiet down mode" do
+          @client.should_receive(:quieting_down?)
+          @system.check_quiet_down
+        end
+      end
+
       describe "#restart" do
         it "sends a safe restart request to the server" do
           @client.should_receive(:api_post_request).with("/safeRestart")

--- a/spec/unit_tests/system_spec.rb
+++ b/spec/unit_tests/system_spec.rb
@@ -41,8 +41,11 @@ describe JenkinsApi::Client::System do
 
       describe "#check_quiet_down" do
         it "checks if the server is presently in quiet down mode" do
-          @client.should_receive(:quieting_down?)
-          @system.check_quiet_down
+          @client.should_receive(:logger).and_return(Logger.new "/dev/null")
+          @root = JenkinsApi::Client::Root.new(@client)
+          @root.should_receive(:quieting_down?)
+          @client.should_receive(:root).and_return(@root)
+          @system.check_quiet_down?
         end
       end
 


### PR DESCRIPTION
The api at Jenkins root URL has information such as the description displayed to users on the home page and if Jenkins is presently in shutdown mode.
