### PR TITLE
adding method to get two lists 1) online nodes and 2) offline nodes

### DIFF
--- a/lib/jenkins_api_client/node.rb
+++ b/lib/jenkins_api_client/node.rb
@@ -211,6 +211,28 @@ module JenkinsApi
         list.each { |node| delete(node) unless node == "master" }
       end
 
+      # This method returns two lists 1) nodes online 2) nodes offline
+      #
+      # @param [String] filter a regex to filter node names
+      # @param [Bool] ignorecase whether to be case sensitive or not
+      #
+      def online_offline_lists(filter = nil, ignorecase = true)
+        @logger.info "Obtaining nodes from jenkins matching filter '#{filter}'"
+        offline_node_names = []
+        online_node_names = []
+        response_json = @client.api_get_request("/computer")
+        response_json["computer"].each do |computer|
+            if computer["displayName"] =~ /#{filter}/i
+              if computer["offline"] == true
+                offline_node_names << computer["displayName"]
+              else
+                online_node_names << computer["displayName"]
+              end
+            end
+        end
+        return online_node_names, offline_node_names
+      end
+
       # This method lists all nodes
       #
       # @param [String] filter a regex to filter node names
@@ -221,9 +243,9 @@ module JenkinsApi
         node_names = []
         response_json = @client.api_get_request("/computer")
         response_json["computer"].each do |computer|
-            if computer["displayName"] =~ /#{filter}/i
-              node_names << computer["displayName"]
-            end
+          if computer["displayName"] =~ /#{filter}/i
+            node_names << computer["displayName"]
+          end
         end
         node_names
       end

--- a/spec/unit_tests/node_spec.rb
+++ b/spec/unit_tests/node_spec.rb
@@ -151,6 +151,19 @@ describe JenkinsApi::Client::Node do
         end
       end
 
+      describe "#online_offline_lists" do
+        it "accepts filter and returns one offline list and one online list of nodes matching the filter" do
+          @client.should_receive(
+              :api_get_request
+          ).with(
+              "/computer"
+          ).and_return(
+              @sample_json_list_response
+          )
+          @node.online_offline_lists("slave").class.should == Array
+        end
+      end
+
       describe "GeneralAttributes" do
         general_attributes = JenkinsApi::Client::Node::GENERAL_ATTRIBUTES
         general_attributes.each do |attribute|
@@ -211,7 +224,7 @@ describe JenkinsApi::Client::Node do
           ).and_return(
             @offline_slave
           )
-          @node.method("is_offline?").call("slave").should be_true
+          @node.method("is_offline?").call("slave").should be true
         end
 
         it "returns false if the node is online" do
@@ -223,7 +236,7 @@ describe JenkinsApi::Client::Node do
           ).and_return(
             @online_slave
           )
-          @node.method("is_offline?").call("slave").should be_false
+          @node.method("is_offline?").call("slave").should be false
         end
 
         it "returns false if the node is online and have a string value on its attr" do
@@ -235,7 +248,7 @@ describe JenkinsApi::Client::Node do
           ).and_return(
             @offline_slave_in_string
           )
-          @node.method("is_offline?").call("slave").should be_true
+          @node.method("is_offline?").call("slave").should be true
         end
 
         it "returns false if the node is online and have a string value on its attr" do
@@ -247,7 +260,7 @@ describe JenkinsApi::Client::Node do
           ).and_return(
             @online_slave_in_string
           )
-          @node.method("is_offline?").call("slave").should be_false
+          @node.method("is_offline?").call("slave").should be false
         end
       end
 
@@ -314,7 +327,7 @@ describe JenkinsApi::Client::Node do
             @offline_slave,
             @online_slave
           )
-          @node.method("toggle_temporarilyOffline").call("slave", "foo bar").should be_false
+          @node.method("toggle_temporarilyOffline").call("slave", "foo bar").should be false
         end
 
         it "fails to toggle an offline status of a node" do


### PR DESCRIPTION
Knowing how many nodes are online and offline helps in maintenance and managing the Jenkins service. There can be alerts sent to admins if the number of nodes offline is greater than a certain percentage of the total number of nodes. A similar threshold can be used to determine if a node can be safely taken offline for cleanup.
