### PR TITLE
Add dynamic depth support for node attributes.

### DIFF
--- a/lib/jenkins_api_client/node.rb
+++ b/lib/jenkins_api_client/node.rb
@@ -244,7 +244,7 @@ module JenkinsApi
       GENERAL_ATTRIBUTES.each do |meth_suffix|
         define_method("get_#{meth_suffix}") do
           @logger.info "Obtaining '#{meth_suffix}' attribute from jenkins"
-          response_json = @client.api_get_request("/computer", "tree=#{path_encode meth_suffix}")
+          response_json = @client.api_get_request("/computer", "tree=#{path_encode meth_suffix}[*[*[*]]]")
           response_json["#{meth_suffix}"]
         end
       end
@@ -266,7 +266,7 @@ module JenkinsApi
         define_method("get_node_#{meth_suffix}") do |node_name|
           @logger.info "Obtaining '#{meth_suffix}' attribute of '#{node_name}'"
           node_name = "(master)" if node_name == "master"
-          response_json = @client.api_get_request("/computer/#{path_encode node_name}", "tree=#{path_encode meth_suffix}")
+          response_json = @client.api_get_request("/computer/#{path_encode node_name}", "tree=#{path_encode meth_suffix}[*[*[*]]]")
           response_json["#{meth_suffix}"]
         end
       end

--- a/spec/unit_tests/node_spec.rb
+++ b/spec/unit_tests/node_spec.rb
@@ -160,7 +160,7 @@ describe JenkinsApi::Client::Node do
                 :api_get_request
               ).with(
                 "/computer",
-                "tree=#{attribute}"
+                "tree=#{attribute}[*[*[*]]]"
               ).and_return(
                 @sample_json_list_response
               )
@@ -260,7 +260,7 @@ describe JenkinsApi::Client::Node do
                 :api_get_request
               ).with(
                 "/computer/slave",
-                "tree=#{attribute}"
+                "tree=#{attribute}[*[*[*]]]"
               ).and_return(
                 @sample_json_computer_response
               )
@@ -272,7 +272,7 @@ describe JenkinsApi::Client::Node do
                 :api_get_request
               ).with(
                 "/computer/(master)",
-                "tree=#{attribute}"
+                "tree=#{attribute}[*[*[*]]]"
               ).and_return(
                 @sample_json_computer_response
               )


### PR DESCRIPTION
Currently, when using tree= against an object, you do not get any depth.  For example with loadStatistics, you only get:
```
{
  "loadStatistics": {}
}
```
Adding `[*[*[*]]]`, you get the full object (3 deep).  This does not cause any trouble with strings, booleans, or numbers.