### PR TITLE
Small fix to login with pry to use login.yml instead of spec.yml

### DIFF
--- a/scripts/login_with_pry.rb
+++ b/scripts/login_with_pry.rb
@@ -33,7 +33,7 @@ def get_from_stdin(prompt, mask = false)
 end
 
 if ARGV.empty?
-  config_file = '~/.jenkins_api_client/spec.yml'
+  config_file = '~/.jenkins_api_client/login.yml'
 else
   config_file = ARGV.shift
 end


### PR DESCRIPTION
Simple path change to let the login_with_pry script run successfully. 
