### PR TITLE
Dropping support for Ruby 1.9 and updating to json 2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 
 rvm:
   - 2.1.5
-  - 1.9.3
 
 script:
   - bundle exec rake unit_tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 
 rvm:
-  - 2.1.5
+  - 2.3.3
 
 script:
   - bundle exec rake unit_tests

--- a/Gemfile
+++ b/Gemfile
@@ -1,20 +1,20 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
-gem "nokogiri", "~> 1.6.0"
-gem "thor", ">= 0.16.0"
-gem "terminal-table", ">= 1.4.0"
-gem "mixlib-shellout", ">= 1.1.0"
-gem 'socksify', ">= 1.7.0"
-gem 'json', '~> 1.0'
+gem 'json', '~> 2.0.2'
+gem 'mixlib-shellout', '>= 1.1.0'
+gem 'nokogiri', '~> 1.6.0'
+gem 'socksify', '>= 1.7.0'
+gem 'terminal-table', '>= 1.4.0'
+gem 'thor', '>= 0.16.0'
 
 group :development do
-  gem "bundler", ">= 1.0"
-  gem "rspec", "~> 2.14.1"
-  gem "simplecov"
-  gem "yard-thor"
-  gem "yard"
-  gem "pry"
-  gem "rake"
-  gem "jeweler"
-  gem "rack", "~> 1.0"
+  gem 'bundler', '>= 1.0'
+  gem 'jeweler'
+  gem 'pry'
+  gem 'rack', '~> 1.0'
+  gem 'rake'
+  gem 'rspec', '~> 2.14.1'
+  gem 'simplecov'
+  gem 'yard'
+  gem 'yard-thor'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -22,7 +22,7 @@ Jeweler::Tasks.new do |gemspec|
 This is a simple and easy-to-use Jenkins Api client with features focused on
 automating Job configuration programaticaly and so forth}
   gemspec.test_files = `git ls-files -- {spec}/*`.split("\n")
-  gemspec.required_ruby_version    = '>= 1.9.2'
+  gemspec.required_ruby_version    = '>= 2.1.5'
   gemspec.rubygems_version = '1.8.17'
 end
 


### PR DESCRIPTION
The version pin to json ~> 1.0 was for Ruby 1.9 support. This removes Ruby 1.9 support and updates to json 2.0.2

Also rubocop. :robot: 