### PR TITLE
disabled color

### DIFF
--- a/lib/jenkins_api_client/job.rb
+++ b/lib/jenkins_api_client/job.rb
@@ -744,6 +744,8 @@ module JenkinsApi
           "not_run"
         when "aborted"
           "aborted"
+        when "disabled"
+          "disabled"
         else
           "invalid"
         end

--- a/spec/unit_tests/job_spec.rb
+++ b/spec/unit_tests/job_spec.rb
@@ -359,6 +359,7 @@ describe JenkinsApi::Client::Job do
           @job.color_to_status("grey").should         == "not_run"
           @job.color_to_status("grey_anime").should   == "running"
           @job.color_to_status("aborted").should      == "aborted"
+          @job.color_to_status("disabled").should     == "disabled"
         end
         it "returns invalid as the output if unknown color is detected" do
           @job.color_to_status("orange").should == "invalid"


### PR DESCRIPTION
Jenkins has [disabled](http://javadoc.jenkins-ci.org/hudson/model/BallColor.html#DISABLED) job color. I've added support of this color. 

FYI There is connected issue https://github.com/arangamani/jenkins_api_client/issues/200