### PR TITLE
Avoid overriding 'server_port' if is passed explicitly

### DIFF
--- a/lib/jenkins_api_client/client.rb
+++ b/lib/jenkins_api_client/client.rb
@@ -129,7 +129,7 @@ module JenkinsApi
       if @server_url
         server_uri = URI.parse(@server_url)
         @server_ip = server_uri.host
-        @server_port = server_uri.port
+        @server_port ||= server_uri.port
         @ssl = server_uri.scheme == "https"
         @jenkins_path = server_uri.path
 


### PR DESCRIPTION
Like `user` and `password` options, I think is better not overriding `server_port` when `server_url` is passed if it was defined explicitly.

Right now:

```ruby
JenkinsApi::Client.new(
  server_url: 'https://my-custom-host',
  server_port: '34567'
)
# URI.parse(@server_url).port => 443
```
If we want pass a custom port using `server_url` is necessary include it in the own `server_url`:

```ruby
JenkinsApi::Client.new(
  server_url: 'https://my-custom-host:34567'
)
# URI.parse(@server_url).port => 34567
```

This way is less flexible if we need to change the port in the future. This change allow the next:

```ruby
JenkinsApi::Client.new(
  server_url: 'https://my-custom-host',
  server_port: '34567'
)
# URI.parse(@server_url).port => 34567
```

