### PR TITLE
modifying compare_versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gemspec
 
 group :development do
   gem "bundler"
+  gem "mixlib-shellout", "2.0.0"
   gem "rspec"
   gem "simplecov"
   gem "yard-thor"

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gemspec
 
 group :development do
   gem "bundler"
-  gem "mixlib-shellout", "2.0.0"
+  gem "mixlib-shellout", "~>2.0.0"
   gem "rspec"
   gem "simplecov"
   gem "yard-thor"

--- a/jenkins_api_client.gemspec
+++ b/jenkins_api_client.gemspec
@@ -23,8 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'nokogiri', '~> 1.6'
   s.add_dependency 'thor', '>= 0.16.0'
   s.add_dependency 'terminal-table', '>= 1.4.0'
-  s.add_dependency 'mixlib-shellout', '>= 1.1.0'
+  s.add_dependency 'mixlib-shellout', '~> 2.0.0'
   s.add_dependency 'socksify', '>= 1.7.0'
   s.add_dependency 'json', '>= 1.0'
 end
-

--- a/lib/jenkins_api_client/client.rb
+++ b/lib/jenkins_api_client/client.rb
@@ -606,21 +606,15 @@ module JenkinsApi
     # number of decimals, but for this gem we only care about the first four.
     # If there are alpha characters, return nil.
     def deconstruct_version_string(version)
-      
+
       vers_array = []
       matches = version.match(/[a-zA-Z]/)
       return nil if matches
       version.scan(/\d+/) { |ver|
         vers_array.push(ver.to_i)
       }
-      if vers_array[2].nil?
-        vers_array[2] = 0
-      end
-      if vers_array[3].nil?
-        vers_array[3] = 0
-      end
-      if !vers_array.empty?
-        return vers_array
+      if !vers_array.compact.empty?
+        return [vers_array[0], vers_array[1], vers_array[2], vers_array[3]].map(&:to_i)
       else
         return nil
       end
@@ -630,7 +624,7 @@ module JenkinsApi
     # if A == B, returns 0
     # if A > B, returns 1
     # if A < B, returns -1
-    # for this gem, we can make the assumption that if Version A's first 2
+    # for this gem, we can make the assumption that if Version A's first 4
     # version places are less than Version B's, we can return -1
     def compare_versions(version_a, version_b)
       if version_a == version_b

--- a/lib/jenkins_api_client/client.rb
+++ b/lib/jenkins_api_client/client.rb
@@ -604,10 +604,13 @@ module JenkinsApi
     # v 1.2 is a lot older than v 1.102 - and simple < > on version
     # strings doesn't work so well. There could be an indefinite
     # number of decimals, but for this gem we only care about the first four.
+    # If there are alpha characters, return nil.
     def deconstruct_version_string(version)
-      # Return an array of all the version numbers or nil
+      
       vers_array = []
-      matches = version.scan(/\d+/) { |ver|
+      matches = version.match(/[a-zA-Z]/)
+      return nil if matches
+      version.scan(/\d+/) { |ver|
         vers_array.push(ver.to_i)
       }
       if vers_array[2].nil?

--- a/spec/unit_tests/client_spec.rb
+++ b/spec/unit_tests/client_spec.rb
@@ -280,10 +280,10 @@ describe JenkinsApi::Client do
           version = @client.deconstruct_version_string(TEST_2_PART_VERSION_STRING)
           version.should_not be_nil
           version.should_not be_empty
-          version.size.should eql 3
+          version.size.should eql 4
           version[0].should eql 1
           version[1].should eql 2
-          version[2].should eql nil
+          version[2].should eql 0
         end
 
         it "takes a version string in the form 'a.b.c' and returns an array [a,b]" do
@@ -291,7 +291,7 @@ describe JenkinsApi::Client do
           version = @client.deconstruct_version_string(TEST_3_PART_VERSION_STRING)
           version.should_not be_nil
           version.should_not be_empty
-          version.size.should eql 3
+          version.size.should eql 4
           version[0].should eql 1
           version[1].should eql 2
           version[2].should eql 3
@@ -303,12 +303,13 @@ describe JenkinsApi::Client do
           ).to raise_error(NoMethodError) # match for fixnum
         end
 
-        it "should return nil if parameter is not a string in the form '\d+.\d+(.\d+)'" do
+        it "should return nil if parameter is not made of integers" do
           @client.deconstruct_version_string("A.B").should be_nil
-          @client.deconstruct_version_string("1").should be_nil
-          @client.deconstruct_version_string("1.").should be_nil
+          @client.deconstruct_version_string("1").should_not be_nil
+          @client.deconstruct_version_string("1.").should_not be_nil
           @client.deconstruct_version_string("1.2.3.4").should_not be_nil
           @client.deconstruct_version_string("abcdefg").should be_nil
+          @client.deconstruct_version_string("1.a.c").should be_nil
         end
       end
 

--- a/spec/unit_tests/client_spec.rb
+++ b/spec/unit_tests/client_spec.rb
@@ -283,7 +283,7 @@ describe JenkinsApi::Client do
           version.size.should eql 3
           version[0].should eql 1
           version[1].should eql 2
-          version[2].should eql 0
+          version[2].should eql nil
         end
 
         it "takes a version string in the form 'a.b.c' and returns an array [a,b]" do
@@ -307,7 +307,8 @@ describe JenkinsApi::Client do
           @client.deconstruct_version_string("A.B").should be_nil
           @client.deconstruct_version_string("1").should be_nil
           @client.deconstruct_version_string("1.").should be_nil
-          @client.deconstruct_version_string("1.2.3.4").should be_nil
+          @client.deconstruct_version_string("1.2.3.4").should_not be_nil
+          @client.deconstruct_version_string("abcdefg").should be_nil
         end
       end
 


### PR DESCRIPTION
modifying deconstruct_version_string and compare_versions to allow for indefinite number of version decimals while still only caring about first 4 places.