### PR TITLE
Remove escape characters from Jenkins response body

### DIFF
--- a/lib/jenkins_api_client/client.rb
+++ b/lib/jenkins_api_client/client.rb
@@ -806,7 +806,7 @@ module JenkinsApi
       # the queue.
       when 200, 201, 302
         if to_send == "body" && send_json
-          return JSON.parse(response.body)
+          return JSON.parse(response.body.gsub("\e", ''))
         elsif to_send == "body"
           return response.body
         elsif to_send == "code"


### PR DESCRIPTION
To fix an issue with the `\e` character which seems like an issue with `JSON.parse` so figured this is a simpler solution (we can discuss alternatives i.e. if we should change to `Oj` ... there).

Closes https://github.com/arangamani/jenkins_api_client/issues/294. 