### PR TITLE
Preserving the cookie when requesting a crumb from crumbIssuer

### DIFF
--- a/lib/jenkins_api_client/client.rb
+++ b/lib/jenkins_api_client/client.rb
@@ -369,6 +369,7 @@ module JenkinsApi
       http.read_timeout = @http_read_timeout
 
       response = http.request(request)
+      @cookies = response["set-cookie"]
       case response
         when Net::HTTPRedirection then
           # If we got a redirect request, follow it (if flag set), but don't


### PR DESCRIPTION

The POST request will include the same cookie

Resolving https://github.com/arangamani/jenkins_api_client/issues/300