### PR TITLE
Crt key and get artifacts by path

### DIFF
--- a/lib/jenkins_api_client/client.rb
+++ b/lib/jenkins_api_client/client.rb
@@ -369,6 +369,7 @@ module JenkinsApi
       http.read_timeout = @http_read_timeout
 
       response = http.request(request)
+      @cookies = response["set-cookie"]
       case response
         when Net::HTTPRedirection then
           # If we got a redirect request, follow it (if flag set), but don't

--- a/lib/jenkins_api_client/job.rb
+++ b/lib/jenkins_api_client/job.rb
@@ -1662,6 +1662,10 @@ module JenkinsApi
         find_artifacts(job_name, build_number).first
       end
 
+      def build_path(job_name, build_number = 0)
+        "job/#{path_encode job_name}/#{build_number}"
+      end
+
       #A Method to check artifact exists path from the Current Build
       #
       # @param [String] job_name


### PR DESCRIPTION
# Crt and Key
    In a Jenkins instance that is behind an https proxy the certificate might be restricted only to peers that have a certificate issued by the authority.
    The jenkins_api_client should send the certificate issued by the authority with the call.
    
    The purpose of the :crt and :key file arguments is to allow for the client to include its crt and key file when making the request and in this way authorizing to the https service.
    
# Verify model
    The certificate of the https service might be self-signed so I have added an option of ":verify_mode" that allows you to override the default verify_mode used to make the connections
    In this way existing clients will not get a different behavior while new clients could specify their verify_mode
    
    Example for calling with crt, key and verify_mode
    ```
    
        # This crt and key files could be generated with
        # openssl pkcs12 -in path.p12 -out newfile.crt.pem -clcerts -nokeys
        # openssl pkcs12 -in path.p12 -out newfile.key.pem -nocerts -nodes
        # This of course is only if you have p12 file.
        JenkinsApi::Client.new(:server_url=>the_url,
                               crt: the_crt,
                               key: the_key,
                               ssl: true,
                               verify_mode: OpenSSL::SSL::VERIFY_NONE,
                               :username=>ENV["JENKINS_USERNAME"],
                               :password=>ENV["JENKINS_PASSWORD"])
    ```
    
# get_artifact_by_path
    
    Sometime you need to get not all the artifacts but a specific artifact. This new method allows you to.
    This is need when the build produces to many artifacts and you only want to download one of them as you only need one of them.
