### PR TITLE
Remove all usages of obsolete URI.escape

### DIFF
--- a/lib/jenkins_api_client/job.rb
+++ b/lib/jenkins_api_client/job.rb
@@ -1687,7 +1687,7 @@ module JenkinsApi
       def find_artifacts(job_name, build_number = nil)
         response_json       = get_build_details(job_name, build_number)
         artifact_path(build_details: response_json).map do |p|
-          URI.escape("#{response_json['url']}artifact/#{p['relativePath']}")
+          path_encode("#{response_json['url']}artifact/#{p['relativePath']}")
         end
       end
 

--- a/spec/unit_tests/job_spec.rb
+++ b/spec/unit_tests/job_spec.rb
@@ -1,6 +1,7 @@
 require File.expand_path('../spec_helper', __FILE__)
 require 'net/http'
 require File.expand_path('../fake_http_response', __FILE__)
+require 'addressable/uri'
 
 describe JenkinsApi::Client::Job do
   context "With properly initialized Client and all methods defined" do
@@ -710,13 +711,13 @@ describe JenkinsApi::Client::Job do
 
       describe "#find_artifact" do
         it "accepts job name and build number and return artifact path" do
-          expected_path = URI.escape("https://example.com/DEFAULT-VIEW/view/VIEW-NAME/job/test_job/2/artifact/somepath/output.json") 
+          expected_path = Addressable::URI.escape("https://example.com/DEFAULT-VIEW/view/VIEW-NAME/job/test_job/2/artifact/somepath/output.json")
           @client.should_receive(:api_get_request).and_return(@sample_json_build_response)
           expect(@job.find_artifact('test_job', 1)).to eql(expected_path)
         end
 
         it "accepts job name and uses latest build number if build number not provided and return artifact path" do
-          expected_path = URI.escape("https://example.com/DEFAULT-VIEW/view/VIEW-NAME/job/test_job/2/artifact/somepath/output.json") 
+          expected_path = Addressable::URI.escape("https://example.com/DEFAULT-VIEW/view/VIEW-NAME/job/test_job/2/artifact/somepath/output.json")
           @client.should_receive(:api_get_request).and_return(@sample_json_job_response, @sample_json_build_response)
           expect(@job.find_artifact('test_job')).to eql(expected_path)
         end


### PR DESCRIPTION
It no longer exists in uri 0.11