### PR TITLE
allow more than 100 levels of nesting

### DIFF
--- a/lib/jenkins_api_client/client.rb
+++ b/lib/jenkins_api_client/client.rb
@@ -806,7 +806,7 @@ module JenkinsApi
       # the queue.
       when 200, 201, 302
         if to_send == "body" && send_json
-          return JSON.parse!(response.body)
+          return JSON.parse(response.body, max_nesting: false)
         elsif to_send == "body"
           return response.body
         elsif to_send == "code"

--- a/lib/jenkins_api_client/client.rb
+++ b/lib/jenkins_api_client/client.rb
@@ -806,7 +806,7 @@ module JenkinsApi
       # the queue.
       when 200, 201, 302
         if to_send == "body" && send_json
-          return JSON.parse(response.body)
+          return JSON.parse!(response.body)
         elsif to_send == "body"
           return response.body
         elsif to_send == "code"


### PR DESCRIPTION
we use jenkins_api_client in the tooling https://github.com/pangea-project/pangea-tooling that produces the KDE neon packages.  recently we have started to hit errors such as 
```/home/carlos/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/json-2.6.3/lib/json/common.rb:216:in `parse': nesting of 101 is too deep (JSON::NestingError)```
json sets an arbirtary nesting limit of 100.  we regularly exceed that number, so this patch just disables the limit.